### PR TITLE
Potential fix for code scanning alert no. 1: Missing CSRF middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,8 @@ const cors = require('cors');
 const cookieParser = require('cookie-parser');
 const mongoose = require('mongoose');
 const router = require('./router/index');
-const errorMiddleware = require('./middlewares/auth-middleware')
+const errorMiddleware = require('./middlewares/auth-middleware');
+const lusca = require('lusca');
 
 const PORT = process.env.PORT || 5000;
 const app = express();
@@ -16,6 +17,7 @@ app.use(cors({
     credentials: true,
     origin: process.env.CLIENT_URL
 }));
+app.use(lusca.csrf());
 app.use('/api', router);
 app.use(errorMiddleware);
 

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "mongodb": "^6.0.0",
     "mongoose": "^8.9.5",
     "nodemailer": "^6.9.2",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"


### PR DESCRIPTION
Potential fix for [https://github.com/kyemets/jwt-authorization/security/code-scanning/1](https://github.com/kyemets/jwt-authorization/security/code-scanning/1)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package provides CSRF protection and can be easily integrated into the existing code. We will install the `lusca` package and then use its CSRF middleware in the Express application.

1. Install the `lusca` package.
2. Import the `lusca` package in the `server/index.js` file.
3. Add the `lusca.csrf()` middleware to the Express application before the routes are defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
