### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/server/service/user-service.js
+++ b/server/service/user-service.js
@@ -8,7 +8,10 @@ const ApiError = require('../exceptions/api-error');
 
 class UserService {
     async registration(email, password) {
-        const candidate = await UserModel.findOne({email})
+        if (typeof email !== "string") {
+            throw ApiError.BadRequest("Invalid email format");
+        }
+        const candidate = await UserModel.findOne({ email: { $eq: email } })
         if (candidate) {
             throw ApiError.BadRequest(`The user with the email address ${email} already exists`)
         }
@@ -26,7 +29,7 @@ class UserService {
     }
 
     async activate(activationLink) {
-        const user = await UserModel.findOne({activationLink})
+        const user = await UserModel.findOne({ activationLink: { $eq: activationLink } })
         if (!user) {
             throw ApiError.BadRequest(`Error link`)
         }
@@ -35,7 +38,10 @@ class UserService {
     }
 
     async login(email, password) {
-        const user = await UserModel.findOne({email});
+        if (typeof email !== "string") {
+            throw ApiError.BadRequest("Invalid email format");
+        }
+        const user = await UserModel.findOne({ email: { $eq: email } });
         if (!user) {
             throw ApiError.BadRequest(`The user with this email ${email} was not found!`)
         }


### PR DESCRIPTION
Potential fix for [https://github.com/kyemets/jwt-authorization/security/code-scanning/2](https://github.com/kyemets/jwt-authorization/security/code-scanning/2)

To fix the problem, we need to ensure that the user-provided `email` parameter is properly sanitized before being used in the MongoDB query. The best way to achieve this is by using the `$eq` operator to ensure that the `email` is treated as a literal value. Additionally, we can add a check to ensure that the `email` parameter is a string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
